### PR TITLE
Use media query

### DIFF
--- a/ui/styles/style.sass
+++ b/ui/styles/style.sass
@@ -45,10 +45,9 @@ body
   max-width: 800px
   display: flex
   padding: 20px
-  flex-wrap: wrap
   .user-list
     min-width: 200px
-  
+
   .messages-container
     flex: 1
     display: flex
@@ -70,3 +69,6 @@ body
       height: 40px
       &:hover
         border: 2px solid darken($color-message-form-border, 20%)
+@media (max-width: 500px)
+  .thread-container
+    flex-direction: column


### PR DESCRIPTION
flex-wrap: wrap が iPhone でうまく動いていないようなのでとりあえず media query を使う

Fix #41 

before

![image](https://cloud.githubusercontent.com/assets/1025246/16551948/0587aeac-41f8-11e6-90a6-984c0deae849.png)

after

![image](https://cloud.githubusercontent.com/assets/1025246/16551943/f1c67fc4-41f7-11e6-9500-819861ee3b2a.png)
