### PR TITLE
More testing on wsserver (and async support)

### DIFF
--- a/test/test_wsserver.ts
+++ b/test/test_wsserver.ts
@@ -71,7 +71,7 @@ describe("wsserver", () => {
       if(success) done()
     })
   })
-  it("must be emit join event if user joins", function (done)  {
+  it("must emit join event if user joins", function (done)  {
     let success = false
     ws1.on('message', (data) => {
       const {ev, value} = JSON.parse(data)
@@ -84,7 +84,7 @@ describe("wsserver", () => {
       if(success) done()
     })
   })
-  it("must be emit left event if user leaves", function (done)  {
+  it("must emit left event if user leaves", function (done)  {
     this.timeout(20 * 1000)
     let success = false
     ws2.on('open', () => {

--- a/test/test_wsserver.ts
+++ b/test/test_wsserver.ts
@@ -43,7 +43,7 @@ describe("wsserver", () => {
     })
   })
   it("did not close connection when ping event is successfully received", function (done)  {
-    this.timeout(10 * 1000)
+    this.timeout(20 * 1000)
     let ping_times = 0
     let success = false
 

--- a/test/test_wsserver.ts
+++ b/test/test_wsserver.ts
@@ -1,22 +1,23 @@
 import {app} from "../server/app"
 import * as WebSocket from "ws"
 
-let port: number
 import "../server/wsserver"
-app.listen(0, null, null, function() {
-  port = this.address().port
-})
 
 describe("wsserver", () => {
 
   let ws1: WebSocket
   let ws2: WebSocket
-  beforeEach(() => {
-    ws1 = new WebSocket(`ws://127.0.0.1:${port}/`, {
-      headers: { "Sec-WebSocket-Accept": "1" }
-    })
-    ws2 = new WebSocket(`ws://127.0.0.1:${port}/`, {
-      headers: { "Sec-WebSocket-Accept": "2" }
+  beforeEach((done) => {
+    let port: number
+    app.listen(0, null, null, function() {
+      port = this.address().port
+      ws1 = new WebSocket(`ws://127.0.0.1:${port}/`, {
+        headers: { "Sec-WebSocket-Accept": "1" }
+      })
+      ws2 = new WebSocket(`ws://127.0.0.1:${port}/`, {
+        headers: { "Sec-WebSocket-Accept": "2" }
+      })
+      done()
     })
   })
   it("enables to connect", (done) => {
@@ -43,6 +44,7 @@ describe("wsserver", () => {
   it("did not close connection when ping event is successfully received", function (done)  {
     this.timeout(10 * 1000)
     let ping_times = 0
+    let success = false
 
     ws1.on('message', (data) => {
       const {ev, value} = JSON.parse(data)
@@ -52,37 +54,62 @@ describe("wsserver", () => {
             "ev": "PONG",
             "value": value
           }
-          ws1.send(JSON.stringify(pong))
+          try {
+            ws1.send(JSON.stringify(pong))
+          } catch(e) {
+            // nothing to do
+          }
           ping_times++
           break
       }
       if (ping_times > 1) {
+        success = true
         ws1.close()
-        done()
       }
+    })
+    ws1.on('close', () => {
+      if(success) done()
     })
   })
   it("must be emit join event if user joins", function (done)  {
-    this.timeout(1 * 1000)
+    let success = false
     ws1.on('message', (data) => {
       const {ev, value} = JSON.parse(data)
       if (ev === "USER_JOIN") {
+        success = true
         ws1.close()
-        done()
       }
+    })
+    ws1.on('close', () => {
+      if(success) done()
     })
   })
   it("must be emit left event if user leaves", function (done)  {
-    this.timeout(2 * 1000)
+    this.timeout(20 * 1000)
+    let success = false
+    ws2.on('open', () => {
+      ws1.close()
+    })
     ws2.on('message', (data) => {
       const {ev, value} = JSON.parse(data)
-      if (ev === "USER_JOIN") {
-        ws1.close()
+      if (ev === "PING") {
+        const pong = {
+          "ev": "PONG",
+          "value": value
+        }
+        try {
+          ws2.send(JSON.stringify(pong))
+        } catch(e) {
+          // nothing to do
+        }
       }
       if (ev === "USER_LEAVE") {
+        success = true
         ws2.close()
-        done()
       }
+    })
+    ws2.on('close', () => {
+      if(success) done()
     })
   })
 })

--- a/test/test_wsserver.ts
+++ b/test/test_wsserver.ts
@@ -1,5 +1,6 @@
 import {app} from "../server/app"
 import * as WebSocket from "ws"
+import * as assert from "power-assert"
 
 import "../server/wsserver"
 
@@ -68,7 +69,7 @@ describe("wsserver", () => {
       }
     })
     ws1.on('close', () => {
-      if(success) done()
+      assert.equal(success, true); done()
     })
   })
   it("must emit join event if user joins", function (done)  {
@@ -81,7 +82,7 @@ describe("wsserver", () => {
       }
     })
     ws1.on('close', () => {
-      if(success) done()
+      assert.equal(success, true); done()
     })
   })
   it("must emit left event if user leaves", function (done)  {
@@ -109,7 +110,7 @@ describe("wsserver", () => {
       }
     })
     ws2.on('close', () => {
-      if(success) done()
+      assert.equal(success, true); done()
     })
   })
 })

--- a/test/test_wsserver.ts
+++ b/test/test_wsserver.ts
@@ -76,7 +76,6 @@ describe("wsserver", () => {
     this.timeout(2 * 1000)
     ws2.on('message', (data) => {
       const {ev, value} = JSON.parse(data)
-      console.log(ev)
       if (ev === "USER_JOIN") {
         ws1.close()
       }


### PR DESCRIPTION
やったこと
- 非同期テストの安定性の向上．
- join/leftイベントのテストの追加．

メモ
`headers: { "Sec-WebSocket-Accept": "1" }` とかついてるのは`Sec-WebSocket-Accept`が同一だと同じクライアントからだと判断されてws1.close()するとws2もcloseされてしまうため．
