### PR TITLE
Do not fetch older messages duplicatedly

### DIFF
--- a/ui/src/thread.ts
+++ b/ui/src/thread.ts
@@ -32,6 +32,7 @@ class Thread extends EventEmitter {
   availableUsers: IUser[] = [];
   currentUser: IUser = null;
   hasOlderMessages = true
+  fetchingOlderMessages = false
 
   constructor() {
     super();
@@ -88,12 +89,16 @@ class Thread extends EventEmitter {
   }
 
   async fetchOlderMessages() {
+    if (this.fetchingOlderMessages) {
+      return
+    }
     if (!this.hasOlderMessages) {
       return
     }
     if (this.messages.length == 0) {
       return
     }
+    this.fetchingOlderMessages = true
     const lastId = this.messages[0].id
     const response = await fetch(`${API_SERVER}/messages?limit=${MESSAGE_PER_PAGE}&nextId=${lastId}`);
     const messages: IMessage[] = await response.json();
@@ -105,6 +110,7 @@ class Thread extends EventEmitter {
       this.latestMessage = null
       this.emit("messagePrepend")
     }
+    this.fetchingOlderMessages = false
   }
 
   newMessage(message: string) {

--- a/ui/src/thread.ts
+++ b/ui/src/thread.ts
@@ -9,7 +9,7 @@ const WS_URL = API_SERVER.indexOf("https") === 0
   ? API_SERVER.replace("https", "wss")
   : API_SERVER.replace("http", "ws")
 
-const MESSAGE_PER_PAGE = 100
+const MESSAGE_PER_PAGE = 20
 
 function completeMessageData(message: IMessage) {
   if (!message.user.iconUrl) {


### PR DESCRIPTION
無限スクロールで古いメッセージの読み込みを間違って複数回しないようにする

Fix #80 
