### PR TITLE
Use document.hasFocus() on notification

### DIFF
--- a/ui/src/notification.ts
+++ b/ui/src/notification.ts
@@ -22,7 +22,7 @@ if (window["Notification"]) {
     const {latestMessage, currentUser} = thread;
     if(latestMessage
        && latestMessage.user.name !== currentUser.name
-       && document.hidden)
+       && !document.hasFocus())
       notify(latestMessage)
   })
 }


### PR DESCRIPTION
ウィンドウ自体が隠れている時にも通知を出すために `document.hasFocus()` を使ったほうがいい気がする
