### PR TITLE
ロゴをGitHubへのリンクにする

### DIFF
--- a/ui/src/views/ThreadView.tsx
+++ b/ui/src/views/ThreadView.tsx
@@ -167,8 +167,11 @@ class MessageForm extends React.Component<{}, UserLoginState> {
 
 const HeaderView = () => {
   return <div className="header">
-    <img className="app-logo" src="logo.png" />
-    <div className="app-name">respass</div>
+    <div className="app-link">
+      <img className="app-logo" src="logo.png" />
+      <div className="app-name">respass</div>
+      <a href="https://github.com/sketchglass/respass" />
+    </div>
     <UserView />
   </div>
 }

--- a/ui/styles/style.sass
+++ b/ui/styles/style.sass
@@ -37,21 +37,33 @@ a
   & > *
     padding-left: 10px
     padding-right: 10px
-  .app-logo
-    width: 24px
-    height: 24px
+  .app-link
     padding-left: $user-list-width + 20px
-    padding-right: 0
-  .app-name
-    font-family: Raleway
-    padding-top: 4px
-    font-size: 22px
-    height: 30px
-    flex: 1
+    display: flex
+    align-items: center
+    position: relative
+    .app-logo
+      width: 24px
+      height: 24px
+      padding-right: 10px
+    .app-name
+      font-family: Raleway
+      padding-top: 4px
+      font-size: 22px
+      height: 30px
+    a
+      position: absolute
+      left: 0
+      top: 0
+      width: 100%
+      height: 100%
+
   .user-view
+    flex: 1
     display: flex
     font-size: 12px
     align-items: center
+    justify-content: flex-end
     .icon
       width: 26px
       height: 26px
@@ -144,7 +156,7 @@ a
 
 @media (max-width: 500px)
   .header
-    .app-logo
+    .app-link
       padding-left: 10px
   .thread
     .user-list


### PR DESCRIPTION
Chrome/Firefox/Safari/iOS Simulator で確認済み
