### PR TITLE
Migrate to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:latest
+MAINTAINER sketchglass <sketchglass.team@gmail.com>
+WORKDIR /respass
+EXPOSE 8080 23000
+ENTRYPOINT ["/respass/docker/bootup.sh"]

--- a/README.md
+++ b/README.md
@@ -13,12 +13,46 @@ Websocket-based chat app implementation written in TypeScript
 
 In production environment, you have to use this application with **https**. If not, the server will automatically redirect to https.
 
-## Prerequisites
+## Development
+
+### With Docker
+
+#### Prerequisites
+
+- Docker
+- Docker Compose
+
+#### Build Images
+
+```
+docker-compose build
+```
+
+#### Update Typings and Node Modules
+```
+docker-compose run --entrypoint docker/init.sh respass
+```
+
+#### Run
+
+```
+docker-compose up
+```
+
+#### Test
+
+```
+docker-compose run --entrypoint docker/test.sh respass
+```
+
+### Manual
+
+#### Prerequisites
 
 - PostgreSQL
 - NodeJS (>=6)
 
-## DB Settings
+#### DB Settings
 
 Create User `respass` with empty password.
 ```
@@ -27,7 +61,7 @@ createdb respass-dev
 createdb respass-test
 ```
 
-## Run
+#### Run
 
 ```
 cp .env.sample .env
@@ -37,7 +71,7 @@ npm run db:migrate
 npm start
 ```
 
-## Testing
+#### Testing
 
 ```
 npm test

--- a/config/db.js
+++ b/config/db.js
@@ -1,6 +1,6 @@
 require('dotenv').config({silent: true});
 
-const {DATABASE_URL} = process.env
+const {DATABASE_URL, DATABASE_URL_DEV, DATABASE_URL_TEST} = process.env
 
 module.exports = {
   production: {
@@ -8,11 +8,11 @@ module.exports = {
     dialect: "postgres",
   },
   development: {
-    url: "postgres://respass:@localhost/respass-dev",
+    url: DATABASE_URL_DEV || "postgres://respass:@localhost/respass-dev",
     dialect: "postgres",
   },
   test: {
-    url: "postgres://respass:@localhost/respass-test",
+    url: DATABASE_URL_TEST || "postgres://respass:@localhost/respass-test",
     dialect: "postgres",
   },
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '2'
+services:
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: 'respass'
+      POSTGRES_USER: 'respass'
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  postgres-dev:
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: 'respass'
+      POSTGRES_USER: 'respass'
+      POSTGRES_DB: 'respass-dev'
+    volumes:
+      - postgres-dev-data:/var/lib/postgresql/data
+
+  postgres-test:
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: 'respass'
+      POSTGRES_USER: 'respass'
+      POSTGRES_DB: 'respass-test'
+
+  respass:
+    build: .
+    env_file: .env
+    ports:
+      - "8080:8080"
+      - "23000:23000"
+    environment:
+      PORT: 8080
+      DATABASE_URL: 'postgres://respass:respass@postgres:5432/respass'
+      DATABASE_URL_DEV: 'postgres://respass:respass@postgres-dev:5432/respass-dev'
+      DATABASE_URL_TEST: 'postgres://respass:respass@postgres-test:5432/respass-test'
+    links:
+      - postgres
+      - postgres-dev
+      - postgres-test
+    volumes:
+      - .:/respass
+
+volumes:
+  postgres-data:
+  postgres-dev-data:

--- a/docker/bootup.sh
+++ b/docker/bootup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+cd /respass
+npm start

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+npm install -g typings
+typings install
+npm install
+npm run db:migrate

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+npm test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:frontend": "cd ui && webpack",
     "build:server": "tsc",
     "build": "npm-run-all --parallel build:*",
-    "watch:frontend": "cd ui && webpack-dev-server -d --inline",
+    "watch:frontend": "cd ui && webpack-dev-server -d --inline --host '0.0.0.0'",
     "open-browser": "node -e 'setTimeout(function(){require(`open`)(`http://127.0.0.1:23000`)}, 2000)'",
     "start:frontend": "npm-run-all --parallel open-browser watch:frontend",
     "start:server": "npm run compile:ts && node ./lib/server/index.js",


### PR DESCRIPTION
## What

I added Dockerfiles and some things.
## Why

To share the environment with the developers. Now we can easily set up development environment with only `docker-compose` commands.
## Notes

This patch supports webpack-dev-server. `docker-compsose up` is an alternative to `npm start`. Docker containers automatically sync under /ui folder. So we won't lose watching feature.
